### PR TITLE
Mention the indentation limitation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ And learn more about the description file format below.
 
 ## Graph description symbols
 
-Parent/child dependency is encoded by indentation.
+Parent/child dependency is encoded by indentation.  The indentation _must_ be the multiple of 4 spaces.
 
 There are three kinds of nodes in the graph
 - Comments are prefixed by one of the following symbol: `//`, `#`


### PR DESCRIPTION
This PR adds a note to the README file to mention that the source file must use exactly 4 spaces of indentation.